### PR TITLE
 Proposal: Add Treasurer and Secretary only

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -87,6 +87,15 @@ Only registered UCSD students may hold office in the organization. Only register
   - Ensures all events are properly promoted to the UC San Diego student body
   - Hosts, at minimum, 1 event per quarter designed for people who are new top open source
 
+- *Treasurer*
+  - Ensures funding for all programs, events, and services
+  - In charge of all club expenses, financial reporting, and any club bank account details
+
+- *Secretary*
+  - Ensures all club-related activity have proper room reservations
+  - Keeps records of all programs, events, and services offered by the club, and makes it available to the public
+  - Takes detailed notes of all board meetings, and makes them available to all club members
+
 ### Elections/Appointments
 
 [TODO]


### PR DESCRIPTION
This PR is on top of #14.

With this proposal, there would be 6️⃣ board positions: President, Project Chair, Workshop Chair, and Events Chair, Secretary, and Treasurer..

The treasurer handles money, secretary handles more club logistical things. *There is no Vice President in this version*.

PPlease 👍 or 👎 this PR if you agree/disagree with the changes, and check out the changes in the `Files changed` button above for more details about these three positions!